### PR TITLE
Reorder constructor parameters initialization

### DIFF
--- a/src/NukiBle.h
+++ b/src/NukiBle.h
@@ -267,17 +267,6 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     Command lastMsgCodeReceived = Command::Empty;
 
   private:
-//Keyturner Pairing Service
-    const NimBLEUUID pairingServiceUUID;
-//Keyturner Service
-    const NimBLEUUID deviceServiceUUID;
-//Keyturner pairing Data Input Output characteristic
-    const NimBLEUUID gdioUUID;
-//User-Specific Data Input Output characteristic
-    const NimBLEUUID userDataUUID;
-
-    const std::string preferencesId;
-
     SemaphoreHandle_t nukiBleSemaphore = xSemaphoreCreateMutex();
     bool takeNukiBleSemaphore(std::string taker);
     std::string owner = "free";
@@ -310,6 +299,17 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     std::string deviceName;       //The name to be displayed for this authorization and used for storing preferences
     uint32_t deviceId;            //The ID of the Nuki App, Nuki Bridge or Nuki Fob to be authorized.
     BLEClient* pClient = nullptr;
+
+//Keyturner Pairing Service
+    const NimBLEUUID pairingServiceUUID;
+//Keyturner Service
+    const NimBLEUUID deviceServiceUUID;
+//Keyturner pairing Data Input Output characteristic
+    const NimBLEUUID gdioUUID;
+//User-Specific Data Input Output characteristic
+    const NimBLEUUID userDataUUID;
+
+    const std::string preferencesId;
 
     BLERemoteService* pKeyturnerPairingService = nullptr;
     BLERemoteCharacteristic* pGdioCharacteristic = nullptr;


### PR DESCRIPTION
Fixes the following error:
```
Compiling .pioenvs/nuki/lib9e7/NukiBleEsp/NukiLockUtils.cpp.o
In file included from .piolibdeps/nuki/NukiBleEsp/src/NukiBle.cpp:13:0:
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.h: In constructor 'Nuki::NukiBle::NukiBle(const string&, uint32_t, NimBLEUUID, NimBLEUUID, NimBLEUUID, NimBLEUUID, std::__cxx11::string)':
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.h:311:14: error: 'Nuki::NukiBle::deviceId' will be initialized after [-Werror=reorder]
     uint32_t deviceId;            //The ID of the Nuki App, Nuki Bridge or Nuki Fob to be authorized.
              ^
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.h:271:22: error:   'const NimBLEUUID Nuki::NukiBle::pairingServiceUUID' [-Werror=reorder]
     const NimBLEUUID pairingServiceUUID;
                      ^
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.cpp:30:1: error:   when initialized here [-Werror=reorder]
 NukiBle::NukiBle(const std::string& deviceName,
 ^
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.cpp: In member function 'void Nuki::NukiBle::getMacAddress(char*)':
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.cpp:583:59: warning: format '%d' expects argument of type 'int', but argument 3 has type 'const char*' [-Wformat=]
       sprintf(macAddress, "%d", address.toString().c_str());
                                                           ^
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.cpp:583:59: warning: format '%d' expects argument of type 'int', but argument 3 has type 'const char*' [-Wformat=]
Archiving .pioenvs/nuki/lib9b0/libBleScanner.a
Compiling .pioenvs/nuki/lib9e7/NukiBleEsp/NukiOpener.cpp.o
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.cpp: In member function 'Nuki::PairingState Nuki::NukiBle::pairStateMachine(Nuki::PairingState)':
.piolibdeps/nuki/NukiBleEsp/src/NukiBle.cpp:684:78: warning: ignoring return value of 'int crypto_scalarmult_curve25519(unsigned char*, const unsigned char*, const unsigned char*)', declared with attribute warn_unused_result [-Wunused-result]
       crypto_scalarmult_curve25519(sharedKeyS, myPrivateKey, remotePublicKey);
                                                                              ^
Compiling .pioenvs/nuki/lib9e7/NukiBleEsp/NukiOpenerUtils.cpp.o
cc1plus: some warnings being treated as errors
*** [.pioenvs/nuki/lib9e7/NukiBleEsp/NukiBle.cpp.o] Error 1
```