### PR TITLE
Fix setName

### DIFF
--- a/src/NukiLock.cpp
+++ b/src/NukiLock.cpp
@@ -113,6 +113,7 @@ Nuki::CmdResult NukiLock::setName(const std::string& name) {
     Config oldConfig;
     Nuki::CmdResult result = requestConfig(&oldConfig);
     if (result == Nuki::CmdResult::Success) {
+      memset(oldConfig.name, 0, sizeof(oldConfig.name));
       memcpy(oldConfig.name, name.c_str(), name.length());
       result = setFromConfig(oldConfig);
     }

--- a/src/NukiOpener.cpp
+++ b/src/NukiOpener.cpp
@@ -113,6 +113,7 @@ Nuki::CmdResult NukiOpener::setName(const std::string& name) {
     Config oldConfig;
     Nuki::CmdResult result = requestConfig(&oldConfig);
     if (result == Nuki::CmdResult::Success) {
+      memset(oldConfig.name, 0, sizeof(oldConfig.name));
       memcpy(oldConfig.name, name.c_str(), name.length());
       result = setFromConfig(oldConfig);
     }


### PR DESCRIPTION
When changing the lock name using setName to a name shorter than the currently set name the extra characters of the old name will not be removed.

This should fix this behaviour.