### PR TITLE
Fix TimeValue struct size (plus a couple minor changes)

### DIFF
--- a/src/NukiBle.cpp
+++ b/src/NukiBle.cpp
@@ -40,7 +40,8 @@ NukiBle::NukiBle(const std::string& deviceName,
     deviceServiceUUID(deviceServiceUUID),
     gdioUUID(gdioUUID),
     userDataUUID(userDataUUID),
-    preferencesId(preferencedId) {
+    preferencesId(preferencedId),
+    errorCode(ErrorCode::ERROR_UNKNOWN) {
 }
 
 NukiBle::~NukiBle() {

--- a/src/NukiBle.cpp
+++ b/src/NukiBle.cpp
@@ -536,7 +536,11 @@ Nuki::CmdResult NukiBle::updateTime(TimeValue time) {
 }
 
 bool NukiBle::saveSecurityPincode(const uint16_t pinCode) {
-  return (preferences.putBytes(SECURITY_PINCODE_STORE_NAME, &pinCode, 2) == 2);
+  if (preferences.putBytes(SECURITY_PINCODE_STORE_NAME, &pinCode, 2) == 2) {
+    this->pinCode = pinCode;
+    return true;
+  }
+  return false;
 }
 
 void NukiBle::saveCredentials() {

--- a/src/NukiConstants.h
+++ b/src/NukiConstants.h
@@ -360,6 +360,6 @@ struct __attribute__((packed)) TimeValue {
   uint8_t day;
   uint8_t hour;
   uint8_t minute;
-  uint16_t second;
+  uint8_t second;
 };
 } // namespace Nuki


### PR DESCRIPTION
The change has been tested with a Nuki Lock 2.0, on an Olimex ESP32-PoE.