### PR TITLE
Fix TimeValue struct size for updateTime

### DIFF
--- a/src/NukiConstants.h
+++ b/src/NukiConstants.h
@@ -360,6 +360,6 @@ struct __attribute__((packed)) TimeValue {
   uint8_t day;
   uint8_t hour;
   uint8_t minute;
-  uint16_t second;
+  uint8_t second;
 };
 } // namespace Nuki


### PR DESCRIPTION
Seconds are 8bit per API doc.

Tested with Nuki Lock 2.0:

- with uint16_t, ERROR_BAD_LENGTH is returned.
- with uint8_t, time is updated correctly.