### PR TITLE
When setting pin code, update in-RAM copy as well

### DIFF
--- a/src/NukiBle.cpp
+++ b/src/NukiBle.cpp
@@ -536,7 +536,11 @@ Nuki::CmdResult NukiBle::updateTime(TimeValue time) {
 }
 
 bool NukiBle::saveSecurityPincode(const uint16_t pinCode) {
-  return (preferences.putBytes(SECURITY_PINCODE_STORE_NAME, &pinCode, 2) == 2);
+  if (preferences.putBytes(SECURITY_PINCODE_STORE_NAME, &pinCode, 2) == 2) {
+    this->pinCode = pinCode;
+    return true;
+  }
+  return false;
 }
 
 void NukiBle::saveCredentials() {


### PR DESCRIPTION
putBytes saves the pin code to flash, where it will be re-read after device restart. pinCode class member is not set, making the current client state invalid.