### PR TITLE
use atomic types for shared variables in onResult

### DIFF
--- a/src/NukiBle.cpp
+++ b/src/NukiBle.cpp
@@ -40,7 +40,11 @@ NukiBle::NukiBle(const std::string& deviceName,
     deviceServiceUUID(deviceServiceUUID),
     gdioUUID(gdioUUID),
     userDataUUID(userDataUUID),
-    preferencesId(preferencedId) {
+    preferencesId(preferencedId)
+{
+  rssi = 0;
+  lastReceivedBeaconTs = 0;
+  lastHeartbeat = 0;
 }
 
 NukiBle::~NukiBle() {

--- a/src/NukiBle.h
+++ b/src/NukiBle.h
@@ -18,6 +18,7 @@
 #include <Preferences.h>
 #include <esp_task_wdt.h>
 #include <BleInterfaces.h>
+#include <atomic>
 #include "sodium/crypto_secretbox.h"
 
 #define GENERAL_TIMEOUT 3000
@@ -363,7 +364,7 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     Nuki::CommandState nukiCommandState = Nuki::CommandState::Idle;
 
     uint32_t timeNow = 0;
-    uint32_t lastHeartbeat = 0;
+    std::atomic_uint lastHeartbeat;
 
     BleScanner::Publisher* bleScanner = nullptr;
     bool isPaired = false;
@@ -388,8 +389,8 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     bool keypadCodeCountReceived = false;
     uint16_t logEntryCount = 0;
     bool loggingEnabled = false;
-    int rssi = 0;
-    unsigned long lastReceivedBeaconTs = 0;
+    std::atomic_int rssi;
+    std::atomic_ulong lastReceivedBeaconTs;
     std::list<KeypadEntry> listOfKeyPadEntries;
     std::list<AuthorizationEntry> listOfAuthorizationEntries;
     AuthorizationIdType authorizationIdType = AuthorizationIdType::Bridge;


### PR DESCRIPTION
Most ESPs have two CPU cores. NimBLE can run on either core, which can be different from the rest of the program. The onResult method in NukiBle is called from the BleScanner which is a wrapper around the onResult callback from NimBLE. This callback potentially runs on a different thread and thus CPU core than the rest of the program, and if writing to a shared variable might result in a crash. Changing the relevant variables to std::atomic types should fix this.