### PR TITLE
Improve pairing reliability and speed

### DIFF
--- a/src/NukiBle.h
+++ b/src/NukiBle.h
@@ -283,7 +283,7 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
 
   protected:
     bool connectBle(const BLEAddress bleAddress);
-    void extendDisonnectTimeout();
+    void extendDisconnectTimeout();
 
     template <typename TDeviceAction>
     Nuki::CmdResult executeAction(const TDeviceAction action);
@@ -319,6 +319,7 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     uint16_t timeoutDuration = 1000;
     uint8_t connectTimeoutSec = 1;
     uint8_t connectRetries = 5;
+    unsigned long pairingLastSeen = 0;
 
     void onConnect(BLEClient*) override;
     void onDisconnect(BLEClient*) override;

--- a/src/NukiBle.hpp
+++ b/src/NukiBle.hpp
@@ -32,7 +32,7 @@ Nuki::CmdResult NukiBle::executeAction(const TDeviceAction action) {
         Nuki::CmdResult result = cmdStateMachine(action);
         if (result != Nuki::CmdResult::Working) {
           giveNukiBleSemaphore();
-          extendDisonnectTimeout();
+          extendDisconnectTimeout();
           return result;
         }
         esp_task_wdt_reset();
@@ -43,7 +43,7 @@ Nuki::CmdResult NukiBle::executeAction(const TDeviceAction action) {
         Nuki::CmdResult result = cmdChallStateMachine(action);
         if (result != Nuki::CmdResult::Working) {
           giveNukiBleSemaphore();
-          extendDisonnectTimeout();
+          extendDisconnectTimeout();
           return result;
         }
         esp_task_wdt_reset();
@@ -54,7 +54,7 @@ Nuki::CmdResult NukiBle::executeAction(const TDeviceAction action) {
         Nuki::CmdResult result = cmdChallAccStateMachine(action);
         if (result != Nuki::CmdResult::Working) {
           giveNukiBleSemaphore();
-          extendDisonnectTimeout();
+          extendDisconnectTimeout();
           return result;
         }
         esp_task_wdt_reset();
@@ -65,7 +65,7 @@ Nuki::CmdResult NukiBle::executeAction(const TDeviceAction action) {
         Nuki::CmdResult result = cmdChallStateMachine(action, true);
         if (result != Nuki::CmdResult::Working) {
           giveNukiBleSemaphore();
-          extendDisonnectTimeout();
+          extendDisconnectTimeout();
           return result;
         }
         esp_task_wdt_reset();

--- a/src/NukiLock.cpp
+++ b/src/NukiLock.cpp
@@ -758,7 +758,7 @@ void NukiLock::createNewAdvancedConfig(const AdvancedConfig* oldConfig, NewAdvan
 }
 
 void NukiLock::handleReturnMessage(Command returnCode, unsigned char* data, uint16_t dataLen) {
-  extendDisonnectTimeout();
+  extendDisconnectTimeout();
 
   switch (returnCode) {
     case Command::KeyturnerStates : {

--- a/src/NukiOpener.cpp
+++ b/src/NukiOpener.cpp
@@ -646,7 +646,7 @@ void NukiOpener::createNewAdvancedConfig(const AdvancedConfig* oldConfig, NewAdv
 
 
 void NukiOpener::handleReturnMessage(Command returnCode, unsigned char* data, uint16_t dataLen) {
-  extendDisonnectTimeout();
+  extendDisconnectTimeout();
 
   switch (returnCode) {
     case Command::KeyturnerStates : {


### PR DESCRIPTION
Improves pairing speed and reliability, especially in environments with many BLE devices.

Current pairing mechanism will log many "Found nuki in pairing state" messages but still not pair and log "No nuki in pairing mode found" when executing the `pairNuki` function.
 
This is caused by other BLE devices resetting the `pairingServiceAvailable` bool before the `pairNuki` function is executed.

By putting the `pairingServiceAvailable` bool on a timer instead of making it dependant on the last seen device by BLEScanner this behaviour can be fixed, increasing pairing speed and reliability.

Also fixes typo in "extendDis**c**onnectTimeout"