### PR TITLE
Misc improvements + Alternative connection mode

### DIFF
--- a/src/NukiBle.h
+++ b/src/NukiBle.h
@@ -71,12 +71,12 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     void updateConnectionState();
 
     /**
-     * @brief Set the BLE Disonnect Timeout, if longer than ~20 sec the lock will disconnect by itself
+     * @brief Set the BLE Disconnect Timeout, if longer than ~20 sec the lock will disconnect by itself
      * if there is no BLE communication
      *
      * @param timeoutMs
      */
-    void setDisonnectTimeout(uint32_t timeoutMs);
+    void setDisconnectTimeout(uint32_t timeoutMs);
 
     /**
      * @brief Set the BLE Connect Timeout in seconds.
@@ -335,6 +335,7 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
     void giveNukiBleSemaphore();
 
     bool connecting = false;
+    bool connected = false;
     uint16_t timeoutDuration = 1000;
     uint8_t connectTimeoutSec = 1;
     uint8_t connectRetries = 5;

--- a/src/NukiBle.hpp
+++ b/src/NukiBle.hpp
@@ -385,6 +385,7 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
         #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
+        extendDisconnectTimeout();
         return Nuki::CmdResult::Success;
       }
       break;
@@ -421,6 +422,7 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
         #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
+        extendDisconnectTimeout();
         return Nuki::CmdResult::Success;
       }
       break;


### PR DESCRIPTION
Couple of small fixes/changes:

- Fix typo in setDis**c**onnectTimeout
- Set TX power to max (9db) by default, based on https://github.com/h2zero/esp-nimble-cpp/blob/master/examples/Advanced/NimBLE_Client/main/main.cpp
- Add extendDisconnectTimeout(); to remaining succesfully completed commands
- Better failure handling while obtaining references to the KeyTurner (Pairing) service, based on https://github.com/h2zero/esp-nimble-cpp/blob/master/examples/Advanced/NimBLE_Client/main/main.cpp


Add an alternative connection mode when `NUKI_ALT_CONNECT` is defined, based on https://github.com/h2zero/esp-nimble-cpp/blob/master/examples/Advanced/NimBLE_Client/main/main.cpp.

Issues reported on Nuki Hub Discord and Github point to dangling BLE connections with the current connect function of this library. The proposed alternative connection mode seems to fix these issues. By using this mode only when `NUKI_ALT_CONNECT` is defined aim for maximum compatibility while testing this mode on a larger group of users.