### PR TITLE
Compatibility with latest esp-nimble-cpp

### DIFF
--- a/src/NukiBle.h
+++ b/src/NukiBle.h
@@ -20,6 +20,7 @@
 #include <BleInterfaces.h>
 #include <atomic>
 #include <string>
+#include <list>
 #include "sodium/crypto_secretbox.h"
 
 #define GENERAL_TIMEOUT 3000


### PR DESCRIPTION
Recent updates to esp-nimble-cpp and NimBLE-Arduino introduced several breaking changes, some of which affect this library.

This PR ensures compatibility with latest esp-nimble-cpp when `NUKI_USE_LATEST_NIMBLE` is defined