### PR TITLE
Allow enable/disable CM in App mode and disconnect/reconnect on failed commands

### DIFF
--- a/src/NukiBle.hpp
+++ b/src/NukiBle.hpp
@@ -112,6 +112,9 @@ Nuki::CmdResult NukiBle::cmdStateMachine(const TDeviceAction action) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ SENDING COMMAND FAILED ************************");
         #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
         return Nuki::CmdResult::Failed;
@@ -125,6 +128,9 @@ Nuki::CmdResult NukiBle::cmdStateMachine(const TDeviceAction action) {
       if ((esp_timer_get_time() / 1000) - timeNow > CMD_TIMEOUT) {
       #endif
         log_w("************************ COMMAND FAILED TIMEOUT************************");
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         return Nuki::CmdResult::TimeOut;
       } else if (lastMsgCodeReceived != Command::ErrorReport && lastMsgCodeReceived != Command::Empty) {
@@ -139,12 +145,18 @@ Nuki::CmdResult NukiBle::cmdStateMachine(const TDeviceAction action) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ COMMAND FAILED ************************");
         #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
         return Nuki::CmdResult::Failed;
       } else if (lastMsgCodeReceived == Command::ErrorReport && errorCode == 69) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ COMMAND FAILED LOCK BUSY ************************");
+        #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
         #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
@@ -154,6 +166,9 @@ Nuki::CmdResult NukiBle::cmdStateMachine(const TDeviceAction action) {
     break;
     default: {
       log_w("Unknown request command state");
+      #ifdef NUKI_ALT_CONNECT
+      pClient->disconnect();
+      #endif
       return Nuki::CmdResult::Failed;
       break;
     }
@@ -182,6 +197,9 @@ Nuki::CmdResult NukiBle::cmdChallStateMachine(const TDeviceAction action, const 
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ SENDING CHALLENGE FAILED ************************");
         #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
         return Nuki::CmdResult::Failed;
@@ -198,6 +216,9 @@ Nuki::CmdResult NukiBle::cmdChallStateMachine(const TDeviceAction action, const 
       if ((esp_timer_get_time() / 1000) - timeNow > CMD_TIMEOUT) {
       #endif
         log_w("************************ COMMAND FAILED TIMEOUT ************************");
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         return Nuki::CmdResult::TimeOut;
       } else if (lastMsgCodeReceived == Command::Challenge) {
@@ -235,6 +256,9 @@ Nuki::CmdResult NukiBle::cmdChallStateMachine(const TDeviceAction action, const 
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ SENDING COMMAND FAILED ************************");
         #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
         return Nuki::CmdResult::Failed;
@@ -251,11 +275,17 @@ Nuki::CmdResult NukiBle::cmdChallStateMachine(const TDeviceAction action, const 
       if ((esp_timer_get_time() / 1000) - timeNow > CMD_TIMEOUT) {
       #endif
         log_w("************************ COMMAND FAILED TIMEOUT ************************");
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         return Nuki::CmdResult::TimeOut;
       } else if (lastMsgCodeReceived == Command::ErrorReport && errorCode != 69) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ COMMAND FAILED ************************");
+        #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
         #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
@@ -263,6 +293,9 @@ Nuki::CmdResult NukiBle::cmdChallStateMachine(const TDeviceAction action, const 
       } else if (lastMsgCodeReceived == Command::ErrorReport && errorCode == 69) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ COMMAND FAILED LOCK BUSY ************************");
+        #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
         #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
@@ -279,6 +312,9 @@ Nuki::CmdResult NukiBle::cmdChallStateMachine(const TDeviceAction action, const 
     }
     default:
       log_w("Unknown request command state");
+      #ifdef NUKI_ALT_CONNECT
+      pClient->disconnect();
+      #endif
       return Nuki::CmdResult::Failed;
       break;
   }
@@ -306,6 +342,9 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ SENDING CHALLENGE FAILED ************************");
         #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
         return Nuki::CmdResult::Failed;
@@ -322,6 +361,9 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
       if ((esp_timer_get_time() / 1000) - timeNow > CMD_TIMEOUT) {
       #endif
         log_w("************************ COMMAND FAILED TIMEOUT ************************");
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         return Nuki::CmdResult::TimeOut;
       } else if (lastMsgCodeReceived == Command::Challenge) {
@@ -352,6 +394,9 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ SENDING COMMAND FAILED ************************");
         #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
         return Nuki::CmdResult::Failed;
@@ -368,6 +413,9 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
       if ((esp_timer_get_time() / 1000) - timeNow > CMD_TIMEOUT) {
       #endif
         log_w("************************ ACCEPT FAILED TIMEOUT ************************");
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         return Nuki::CmdResult::TimeOut;
       } else if (lastMsgCodeReceived == Command::Status && (CommandStatus)receivedStatus == CommandStatus::Accepted) {
@@ -400,11 +448,17 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
       if ((esp_timer_get_time() / 1000) - timeNow > CMD_TIMEOUT) {
       #endif
         log_w("************************ COMMAND FAILED TIMEOUT ************************");
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
+        #endif
         nukiCommandState = CommandState::Idle;
         return Nuki::CmdResult::TimeOut;
       } else if (lastMsgCodeReceived == Command::ErrorReport && errorCode != 69) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ COMMAND FAILED ************************");
+        #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
         #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
@@ -412,6 +466,9 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
       } else if (lastMsgCodeReceived == Command::ErrorReport && errorCode == 69) {
         #ifdef DEBUG_NUKI_COMMUNICATION
         log_d("************************ COMMAND FAILED LOCK BUSY ************************");
+        #endif
+        #ifdef NUKI_ALT_CONNECT
+        pClient->disconnect();
         #endif
         nukiCommandState = CommandState::Idle;
         lastMsgCodeReceived = Command::Empty;
@@ -429,6 +486,9 @@ Nuki::CmdResult NukiBle::cmdChallAccStateMachine(const TDeviceAction action) {
     }
     default:
       log_w("Unknown request command state");
+      #ifdef NUKI_ALT_CONNECT
+      pClient->disconnect();
+      #endif
       return Nuki::CmdResult::Failed;
       break;
   }

--- a/src/NukiOpener.cpp
+++ b/src/NukiOpener.cpp
@@ -17,10 +17,10 @@ NukiOpener::NukiOpener(const std::string& deviceName, const uint32_t deviceId)
 Nuki::CmdResult NukiOpener::lockAction(const LockAction lockAction, const uint32_t nukiAppId, const uint8_t flags, const char* nameSuffix, const uint8_t nameSuffixLen) {
   Action action;
   
-  if(((int)lockAction == 4 || (int)lockAction == 5) && nukiAppId != 1)
+  if((lockAction == 0x04 || lockAction == 0x05) && nukiAppId != 1)
   {
       ContinuousModeAction continuousModeAction;
-      continuousModeAction.enabled = ((int)lockAction == 4 ? 1 : 0);
+      continuousModeAction.enabled = (lockAction == 0x04 ? 1 : 0);
       unsigned char payload[sizeof(ContinuousModeAction)] = {0};
       memcpy(payload, &continuousModeAction, sizeof(ContinuousModeAction));
 

--- a/src/NukiOpener.cpp
+++ b/src/NukiOpener.cpp
@@ -17,10 +17,10 @@ NukiOpener::NukiOpener(const std::string& deviceName, const uint32_t deviceId)
 Nuki::CmdResult NukiOpener::lockAction(const LockAction lockAction, const uint32_t nukiAppId, const uint8_t flags, const char* nameSuffix, const uint8_t nameSuffixLen) {
   Action action;
   
-  if((lockAction == 0x04 || lockAction == 0x05) && nukiAppId != 1)
+  if((lockAction == LockAction::ActivateCM || lockAction == LockAction::DeactivateCM) && nukiAppId != 1)
   {
       ContinuousModeAction continuousModeAction;
-      continuousModeAction.enabled = (lockAction == 0x04 ? 1 : 0);
+      continuousModeAction.enabled = (lockAction == LockAction::ActivateCM ? 1 : 0);
       unsigned char payload[sizeof(ContinuousModeAction)] = {0};
       memcpy(payload, &continuousModeAction, sizeof(ContinuousModeAction));
 

--- a/src/NukiOpenerConstants.h
+++ b/src/NukiOpenerConstants.h
@@ -276,6 +276,11 @@ struct __attribute__((packed)) NewTimeControlEntry {
   LockAction lockAction;
 };
 
+struct __attribute__((packed)) ContinuousModeAction {
+  uint8_t enabled;
+  uint8_t timeout;
+};
+
 enum class LoggingType : uint8_t {
   LoggingEnabled            = 0x01,
   LockAction                = 0x02,


### PR DESCRIPTION
- CM
According to the API Continuous mode can only be disabled/enabled when paired as an App using the LockAction.
When paired as app CM can still be enabled/disabled using the separate command available for this (0x0057), although this does require a valid PIN to be set.

- Disconnect on failed commands
NUKI_ALT_CONNECT mode tries to reuse connections as much as possible. This can lead to stuck connections in some cases. This PR disconnects (and reconnects) when commands fail instead of trying to reuse the failing connection (when NUKI_ALT_CONNECT is defined).