### PR TITLE
Signal KeyTurnerStatusReset

### DIFF
--- a/src/NukiBle.cpp
+++ b/src/NukiBle.cpp
@@ -504,6 +504,16 @@ void NukiBle::onResult(BLEAdvertisedDevice* advertisedDevice) {
             if (eventHandler) {
               eventHandler->notify(EventType::KeyTurnerStatusUpdated);
             }
+            
+            statusUpdated = true;
+          }
+          else if (statusUpdated)
+          {
+            statusUpdated = false;
+            
+            if (eventHandler) {
+              eventHandler->notify(EventType::KeyTurnerStatusReset);
+            }
           }
         }
       }

--- a/src/NukiBle.h
+++ b/src/NukiBle.h
@@ -351,6 +351,7 @@ class NukiBle : public BLEClientCallbacks, public BleScanner::Subscriber {
 
     bool connecting = false;
     bool connected = false;
+    bool statusUpdated = false;
     uint16_t timeoutDuration = 1000;
     uint8_t connectTimeoutSec = 1;
     uint8_t connectRetries = 5;

--- a/src/NukiDataTypes.h
+++ b/src/NukiDataTypes.h
@@ -18,7 +18,8 @@
 namespace Nuki {
 
 enum class EventType {
-  KeyTurnerStatusUpdated
+  KeyTurnerStatusUpdated,
+  KeyTurnerStatusReset
 };
 
 class SmartlockEventHandler {


### PR DESCRIPTION
Signal the eventhandler when the KeyTurnerStatusUpdated beacon changes back to the default beacon (after the bridge device has checked the keyturnerstatus)